### PR TITLE
Allow encoding to be set for a new database cluster

### DIFF
--- a/providers/pg_cluster.rb
+++ b/providers/pg_cluster.rb
@@ -32,7 +32,7 @@ action :init do
 
   # Initialize the cluster
   execute "initialize_cluster_#{new_resource.data_dir}" do
-    command "initdb --pgdata #{new_resource.data_dir} --locale C"
+    command "initdb --pgdata #{new_resource.data_dir} --locale C --encoding #{new_resource.encoding}"
     user node[project_name]['postgresql']['username']
     not_if { ::File.exists?(::File.join(new_resource.data_dir, "PG_VERSION")) }
   end

--- a/resources/pg_cluster.rb
+++ b/resources/pg_cluster.rb
@@ -5,3 +5,7 @@ default_action :init
 attribute :data_dir,
 :kind_of => String,
 :name_attribute => true
+
+attribute :encoding,
+:kind_of => String,
+:default => 'SQL_ASCII'


### PR DESCRIPTION
It defaults to SQL_ASCII because that's what we've been using to this
point.  I don't want to break any other users of this cookbook just
yet.
