### PR TITLE
svdir_line has replacements, so needs double-quotes

### DIFF
--- a/recipes/runit_sysvinit.rb
+++ b/recipes/runit_sysvinit.rb
@@ -9,7 +9,7 @@ install_path = node[project_name]['install_path']
 init_id = node[project_name]['sysvinit_id'] || 'SV'
 
 # We assume you are sysvinit
-svdir_line = '#{init_id}:123456:respawn:#{install_path}/embedded/bin/runsvdir-start'
+svdir_line = "#{init_id}:123456:respawn:#{install_path}/embedded/bin/runsvdir-start"
 execute "echo '#{svdir_line}' >> /etc/inittab" do
   not_if "grep '#{svdir_line}' /etc/inittab"
   notifies :run, "execute[init q]", :immediately


### PR DESCRIPTION
RHEL5 builds were broken - now they're not.

cc @seth @christophermaier 
