### PR TITLE
Bump to 0.4.4 because @jamesc already tagged 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-# 0.4.3 - 2014-07-18
+# 0.4.4 - 2014-07-18
 - [OC-11575] Don't start services by default in HA topology
+
+# 0.4.3 - 2014-05-27
+- unbreak runit setup on sysv style init (RHEL5)
 
 # 0.4.2 - 2014-05-13
 - Enable a cluster's default encoding to be specified

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,6 @@ name             'enterprise'
 license          'All rights reserved'
 description      'Installs common libraries and resources for Enterprise Chef and closed-source additions'
 long_description 'Installs common libraries and resources for Enterprise Chef and closed-source additions'
-version          '0.4.3'
+version          '0.4.4'
 
 depends          'runit', '> 1.0.0'


### PR DESCRIPTION
resync CHANGELOG.md with the releases notes
