### PR TITLE
Allow project to override the name of the ctl script

### DIFF
--- a/recipes/runit_upstart.rb
+++ b/recipes/runit_upstart.rb
@@ -7,6 +7,8 @@
 project_name = node['enterprise']['name'].clone
 project_name.gsub!(/_/, '-') if project_name == 'private_chef'
 
+ctl_name = node[node['enterprise']['name']]['ctl_name'] || "#{project_name}-ctl"
+
 # Ensure the previous named iteration of the system job is nuked
 execute "initctl stop opscode-runsvdir" do
   only_if "initctl status opscode-runsvdir | grep start"
@@ -23,7 +25,7 @@ template "/etc/init/#{project_name}-runsvdir.conf" do
   mode "0644"
   variables({
               :install_path => node[node['enterprise']['name']]['install_path'],
-              :project_name => project_name
+              :ctl_name => ctl_name
   })
   source "init-runsvdir.erb"
 end

--- a/templates/default/init-runsvdir.erb
+++ b/templates/default/init-runsvdir.erb
@@ -5,7 +5,7 @@ pre-stop script
    # To avoid Enterprise Chef service processes from being orphaned,
    # we need to ensure everything is stopped before we kill our
    # runsvdir process.
-   /usr/bin/<%= @project_name %>-ctl stop
+   /usr/bin/<%= @ctl_name %> stop
 end script
 post-stop script
    # To avoid stomping on runsv's owned by a different runsvdir


### PR DESCRIPTION
This defaults to #{project_name}-ctl, but e.g. for analytics the project
name is 'analytics', while the script is 'opscode-analytics-ctl'
