### PR TITLE
Making it possible to pass arbitrary attrs to runit resources

### DIFF
--- a/definitions/component_runit_service.rb
+++ b/definitions/component_runit_service.rb
@@ -9,6 +9,7 @@ define :component_runit_service, :package => 'private_chef',
                                  :svlogd_num => nil,
                                  :ha => nil,
                                  :control => nil,
+                                 :runit_attributes => {},
                                  :action => :enable do
   package = params[:package]
   component = params[:name]
@@ -40,6 +41,9 @@ define :component_runit_service, :package => 'private_chef',
     options(
       :log_directory => log_directory
     )
+    params[:runit_attributes].each do |attr_name, attr_value|
+      send(attr_name.to_sym, attr_value)
+    end
   end
 
   if params[:action] == :down

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,6 @@ name             'enterprise'
 license          'All rights reserved'
 description      'Installs common libraries and resources for Enterprise Chef and closed-source additions'
 long_description 'Installs common libraries and resources for Enterprise Chef and closed-source additions'
-version          '0.4.7'
+version          '0.4.8'
 
 depends          'runit', '> 1.0.0'


### PR DESCRIPTION
As opposed to just 'control' and 'options' previously.
Still keeping these 2 for backward compatibility though.
