### PR TITLE
Use action do .. end instead of method def

### DIFF
--- a/libraries/provider_component_runit_supervisor_sysvinit.rb
+++ b/libraries/provider_component_runit_supervisor_sysvinit.rb
@@ -11,7 +11,7 @@ class Chef
 
         use_inline_resources
 
-        def action_create
+        action :create do
           execute "echo '#{svdir_line}' >> /etc/inittab" do
             not_if "grep '#{svdir_line}' /etc/inittab"
             notifies :run, "execute[init q]", :immediately
@@ -22,7 +22,7 @@ class Chef
           end
         end
 
-        def action_delete
+        action :delete do
           Dir["#{new_resource.install_path}/service/*"].each do |svc|
             execute "#{new_resource.install_path}/embedded/bin/sv stop #{svc}" do
               retries 5


### PR DESCRIPTION
When we use `inline_resources` we have to declare the actions with the following format:
```ruby
action :create do
   ... 
end
```

Instead of: 
```ruby
def action_create
   ... 
end
```

Otherwise the resources are never executed.