### PR TITLE
Use action do .. end instead of method def

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -49,7 +49,7 @@ module EnterpriseChef
       when 'tier'
         role == 'backend'
       when 'ha'
-        if (role == 'backend')
+        if role == 'backend'
           dir = node[project_name]['keepalived']['dir']
           cluster_status_file = "#{dir}/current_cluster_status"
 

--- a/libraries/provider_component_runit_supervisor_systemd.rb
+++ b/libraries/provider_component_runit_supervisor_systemd.rb
@@ -10,7 +10,7 @@ class Chef
 
         use_inline_resources
 
-        def action_create
+        action :create do
           template "/usr/lib/systemd/system/#{unit_name}" do
             cookbook "enterprise"
             owner "root"
@@ -29,7 +29,7 @@ class Chef
           end
         end
 
-        def action_delete
+        action :delete do
           Dir["#{new_resource.install_path}/service/*"].each do |svc|
             execute "#{new_resource.install_path}/embedded/bin/sv stop #{svc}" do
               retries 5

--- a/libraries/provider_component_runit_supervisor_sysvinit.rb
+++ b/libraries/provider_component_runit_supervisor_sysvinit.rb
@@ -11,7 +11,7 @@ class Chef
 
         use_inline_resources
 
-        def action_create
+        action :create do
           execute "echo '#{svdir_line}' >> /etc/inittab" do
             not_if "grep '#{svdir_line}' /etc/inittab"
             notifies :run, "execute[init q]", :immediately
@@ -22,7 +22,7 @@ class Chef
           end
         end
 
-        def action_delete
+        action :delete do
           Dir["#{new_resource.install_path}/service/*"].each do |svc|
             execute "#{new_resource.install_path}/embedded/bin/sv stop #{svc}" do
               retries 5

--- a/libraries/provider_component_runit_supervisor_upstart.rb
+++ b/libraries/provider_component_runit_supervisor_upstart.rb
@@ -12,7 +12,7 @@ class Chef
 
         use_inline_resources
 
-        def action_create
+        action :create do
           # Ensure the previous named iteration of the system job is nuked
           execute "initctl stop opscode-runsvdir" do
             only_if "initctl status opscode-runsvdir | grep start"
@@ -49,7 +49,7 @@ class Chef
           end
         end
 
-        def action_delete
+        action :delete do
           service "#{project_name}-runsvdir" do
             provider Chef::Provider::Service::Upstart
             action [:stop, :disable]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs common libraries and resources for Chef server and add-ons'
 long_description   IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.9.0'
+version           '0.9.1'
 
 depends          'runit', '> 1.0.0'
 


### PR DESCRIPTION
When we use `inline_resources` we have to declare the actions with the
following format:
```ruby
action :create do
   ...
end
```

Instead of:
```ruby
def action_create
   ...
end
```

Otherwise the resources are never executed.