### PR TITLE
Add suse support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/BracesAroundHashParameters:
   Enabled: false
@@ -63,5 +63,7 @@ Style/StringLiterals:
   Enabled: false
 Style/TrailingBlankLines:
   Enabled: false
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+Style/TrailingCommaInArguments:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 5.0'
-  gem 'rubocop', '~> 0.34'
+  gem 'rubocop', '~> 0.37'
   gem 'rake'
 end
 

--- a/definitions/component_runit_service.rb
+++ b/definitions/component_runit_service.rb
@@ -46,7 +46,7 @@ define :component_runit_service, :package => 'private_chef',
     end
   end
 
-  if params[:action] == :down
+  if params[:action] == :down # ignore ~FC023 - this is a definition
     log "stop runit_service[#{component}]" do
       notifies :down, "runit_service[#{component}]", :immediately
     end

--- a/libraries/provider_component_runit_supervisor_sysvinit.rb
+++ b/libraries/provider_component_runit_supervisor_sysvinit.rb
@@ -4,7 +4,9 @@ class Chef
   class Provider
     class ComponentRunitSupervisor
       class Sysvinit < Chef::Provider::LWRPBase
-        provides :component_runit_supervisor, :platform => "suse"
+        provides :component_runit_supervisor, :platform_family => "suse" do |node|
+          node['platform_version'].to_i == 11
+        end
         provides :component_runit_supervisor, :platform => "debian"
         provides :component_runit_supervisor, :platform_family => "rhel" do |node|
           node['platform_version'].to_i == 5

--- a/libraries/provider_component_runit_supervisor_sysvinit.rb
+++ b/libraries/provider_component_runit_supervisor_sysvinit.rb
@@ -4,6 +4,7 @@ class Chef
   class Provider
     class ComponentRunitSupervisor
       class Sysvinit < Chef::Provider::LWRPBase
+        provides :component_runit_supervisor, :platform => "suse"
         provides :component_runit_supervisor, :platform => "debian"
         provides :component_runit_supervisor, :platform_family => "rhel" do |node|
           node['platform_version'].to_i == 5

--- a/libraries/provider_component_runit_supervisor_upstart.rb
+++ b/libraries/provider_component_runit_supervisor_upstart.rb
@@ -7,9 +7,11 @@ class Chef
         provides :component_runit_supervisor, :platform_family => "rhel" do |node|
           node['platform_version'].to_i == 6
         end
+        provides :component_runit_supervisor, :platform => "fedora" do |node|
+          node['platform_version'].to_i <= 14
+        end
         provides :component_runit_supervisor,
-          :platform => %w[ amazon fedora ubuntu ]
-
+          :platform => %w[ amazon ubuntu ]
         use_inline_resources
 
         action :create do

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -27,7 +27,7 @@ node.set['runit']['lsb_init_dir'] = "#{install_path}/init"
 
 component_runit_supervisor node['enterprise']['name'] do
   ctl_name node[node['enterprise']['name']]['ctl_name'] ||
-    "#{node['enterprise']['name']}-ctl"
+           "#{node['enterprise']['name']}-ctl"
   sysvinit_id node[node['enterprise']['name']]['sysvinit_id']
   install_path node[node['enterprise']['name']]['install_path']
 end

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -277,6 +277,25 @@ describe 'enterprise_test::component_runit_supervisor_create' do
         it_behaves_like 'systemd create'
       end
 
+      context 'when on SuSE 11' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'suse', version: '11.3',
+                                   step_into: ['component_runit_supervisor']
+        end
+
+        it_behaves_like 'sysvinit create'
+      end
+
+      context 'when on SuSE 12 with systemd' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'suse', version: '12.0', step_into: ['component_runit_supervisor'] do |node|
+            node.default['init_package'] = 'systemd'
+          end
+        end
+
+        it_behaves_like 'systemd create'
+      end
+
       context 'when on Ubuntu' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'ubuntu', version: '12.04',
@@ -357,6 +376,26 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
         it_behaves_like 'systemd delete'
       end
+
+      context 'when on SuSE 11' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'suse', version: '11.3',
+                                   step_into: ['component_runit_supervisor']
+        end
+
+        it_behaves_like 'sysvinit delete'
+      end
+
+      context 'when on SuSE 12 with systemd' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'suse', version: '12.0', step_into: ['component_runit_supervisor'] do |node|
+            node.default['init_package'] = 'systemd'
+          end
+        end
+
+        it_behaves_like 'systemd delete'
+      end
+
 
       context 'when on Ubuntu' do
         let(:runner) do

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -242,11 +242,12 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
       context 'when on Fedora' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'fedora', version: '20',
-                                   step_into: ['component_runit_supervisor']
+          ChefSpec::SoloRunner.new platform: 'fedora', version: '20', step_into: ['component_runit_supervisor'] do |node|
+            node.default['init_package'] = 'systemd'
+          end
         end
 
-        it_behaves_like 'upstart create'
+        it_behaves_like 'systemd create'
       end
 
       context 'when on RHEL 5' do
@@ -342,11 +343,12 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
       context 'when on Fedora' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'fedora', version: '20',
-                                   step_into: ['component_runit_supervisor']
+          ChefSpec::SoloRunner.new platform: 'fedora', version: '20', step_into: ['component_runit_supervisor'] do |node|
+            node.default['init_package'] = 'systemd'
+          end
         end
 
-        it_behaves_like 'upstart delete'
+        it_behaves_like 'systemd delete'
       end
 
       context 'when on RHEL 5' do
@@ -386,7 +388,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'sysvinit delete'
       end
 
-      context 'when on SuSE 12 with systemd' do
+      context 'when on SuSE 12' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'suse', version: '12.0', step_into: ['component_runit_supervisor'] do |node|
             node.default['init_package'] = 'systemd'

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -396,7 +396,6 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'systemd delete'
       end
 
-
       context 'when on Ubuntu' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'ubuntu', version: '12.04',


### PR DESCRIPTION
Currently when you try to run an omnibus installer on Suse or SLES you receive a NilClass error on runit services. This defines the correct runit supervisor, at least on SLES11. We will probably need to split this eventually based on Suse version as I believe SLES12 is not SysV.