### PR TITLE
Install unit files in `/etc/systemd/system`

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,9 @@ platforms:
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]
+  - name: ubuntu-16.04
+    run_list:
+      - recipe[apt::default]
 
 suites:
   - name: component_runit_supervisor_create

--- a/libraries/provider_component_runit_supervisor_systemd.rb
+++ b/libraries/provider_component_runit_supervisor_systemd.rb
@@ -11,7 +11,7 @@ class Chef
         use_inline_resources
 
         action :create do
-          template "/usr/lib/systemd/system/#{unit_name}" do
+          template "/etc/systemd/system/#{unit_name}" do
             cookbook "enterprise"
             owner "root"
             group "root"
@@ -42,7 +42,7 @@ class Chef
             provider Chef::Provider::Service::Systemd
           end
 
-          file "/usr/lib/systemd/system/#{unit_name}" do
+          file "/etc/systemd/system/#{unit_name}" do
             action :delete
           end
         end

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.shared_examples 'systemd create' do
   it 'renders the unit template' do
     expect(chef_run).to create_template(
-      "/usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service"
+      "/etc/systemd/system/#{enterprise_name}-runsvdir-start.service"
     ).with(
       owner: 'root',
       group: 'root',
@@ -141,7 +141,7 @@ RSpec.shared_examples 'systemd delete' do
 
   it 'deletes the unit file' do
     expect(chef_run).to delete_file(
-      "/usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service"
+      "/etc/systemd/system/#{enterprise_name}-runsvdir-start.service"
     )
   end
 end

--- a/test/integration/component_runit_supervisor_create/serverspec/systemd_spec.rb
+++ b/test/integration/component_runit_supervisor_create/serverspec/systemd_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
-if os[:family] == "redhat" && os[:release].to_i == 7
+if (os[:family] == "redhat" && os[:release].to_i == 7) ||
+   (os[:family] == "ubuntu" && os[:release] == "16.04")
   describe service("testproject-runsvdir-start.service") do
-    it { should be_running }
+    it { should be_running.under('systemd') }
   end
 end

--- a/test/integration/component_runit_supervisor_create/serverspec/upstart_spec.rb
+++ b/test/integration/component_runit_supervisor_create/serverspec/upstart_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 if (os[:family] == "redhat" && os[:release].to_i == 6) ||
-   os[:family] == "ubuntu"
+   (os[:family] == "ubuntu" && os[:release] != "16.04")
   describe command("initctl status testproject-runsvdir") do
     its(:stdout) { should match(/start\/running/) }
   end


### PR DESCRIPTION
### Description
Install unit files in `/etc/systemd/system`. `systemd` gives this location priority.

### Issues Resolved
[chef-server #572](https://github.com/chef/chef-server/issues/572)

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

