### PR TITLE
Remove unit files created in /usr/lib/systemd/system by previous cookbook versions

### DIFF
--- a/libraries/provider_component_runit_supervisor_systemd.rb
+++ b/libraries/provider_component_runit_supervisor_systemd.rb
@@ -23,6 +23,15 @@ class Chef
             source "runsvdir-start.service.erb"
           end
 
+          # This cookbook originally installed its unit files in /usr/lib/systemd/system.
+          execute "cleanup_old_unit_files" do
+            command <<-EOH
+              rm /usr/lib/systemd/system/#{unit_name}
+              systemctl daemon-reload
+            EOH
+            only_if { ::File.exist?("/usr/lib/systemd/system/#{unit_name}") }
+          end
+
           service unit_name do
             action [:enable, :start]
             provider Chef::Provider::Service::Systemd

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -16,6 +16,15 @@ RSpec.shared_examples 'systemd create' do
     )
   end
 
+  # TODO:  Get this working with the guard.
+  it 'removes unit files previously created in /usr/lib/systemd/system' do
+    allow(::File).to receive(:exist?).and_call_original
+    allow(::File).to receive(:exist?).with("/usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service").and_return true
+    expect(chef_run).to run_execute("cleanup_old_unit_files").with(
+      command: "              rm /usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service\n              systemctl daemon-reload\n"
+    )
+  end
+
   it 'enables the service' do
     expect(chef_run).to enable_service("#{enterprise_name}-runsvdir-start.service").with(
       provider: Chef::Provider::Service::Systemd


### PR DESCRIPTION
### Description

Remove unit files created in `/usr/lib/systemd/system` by previous versions of this cookbook.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD