### PR TITLE
Bump cookbook metadata version to 0.10.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Enterprise Cookbook Change Log
 
+## 0.10.1 (2016-06-07)
+
+* Put systemd unit files in /etc/systemd/system; clean up files previously placed
+  in /usr/lib/systemd/system.
+
+## 0.10.0 (2016-02-11)
+
+* SUSE support.
+
 ## 0.9.0 (2015-10-08)
 
 * Relax RuboCop rules

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs common libraries and resources for Chef server and add-ons'
 long_description   IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.10.0'
+version           '0.10.1'
 
 depends          'runit', '> 1.0.0'
 


### PR DESCRIPTION
### Description

Bump cookbook version to 0.10.1.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


