### PR TITLE
Yvovandoorn/wait for network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Enterprise Cookbook Change Log
 
+## 0.10.2 (2016-08-10)
+
+* Add directive to systemd file to wait for network to be up to avoid process (elasticsearch) coming up thinking there is no network configured.
+
+## 0.10.1 (2016-06-07)
+
+* Put systemd unit files in /etc/systemd/system; clean up files previously placed
+  in /usr/lib/systemd/system.
+
+## 0.10.0 (2016-02-11)
+
+* SUSE support.
+
 ## 0.9.0 (2015-10-08)
 
 * Relax RuboCop rules

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs common libraries and resources for Chef server and add-ons'
 long_description   IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.10.0'
+version           '0.10.2'
 
 depends          'runit', '> 1.0.0'
 

--- a/templates/default/runsvdir-start.service.erb
+++ b/templates/default/runsvdir-start.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=<%= @project_name %> Runit Process Supervisor
+After=network.target auditd.service
 
 [Service]
 ExecStart=<%= @install_path %>/embedded/bin/runsvdir-start


### PR DESCRIPTION
### Description

This change fixes an issue encountered when Automate starts up too quickly upon reboot of the server. Occasionally the network (witnessed on AWS & vagrant) would not be ready yet and the Elasticsearch process would start in a state where there was no network on RHEL 7.

This fixes the systemd file to only start the main process (runit) to start *after* the network & auditd daemon has come up, similar to what the chef-client cookbook does (https://github.com/chef-cookbooks/chef-client/blob/master/templates/default/systemd/chef-client.service.erb)

### Issues Resolved

No open PR 

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

