### PR TITLE
Use node.override instead of node.set.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs common libraries and resources for Chef server and add-ons'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.10.2'
+version '0.10.3'
 
 depends 'runit', '> 1.6.0'
 

--- a/recipes/runit.rb
+++ b/recipes/runit.rb
@@ -18,12 +18,12 @@ project_name = node['enterprise']['name']
 node.default_unless[node['enterprise']['name']] = {} # ~FC047 (See https://github.com/acrmp/foodcritic/issues/225)
 install_path = node[project_name]['install_path']
 
-node.set['runit']['sv_bin']       = "#{install_path}/embedded/bin/sv"
-node.set['runit']['svlogd_bin']   = "#{install_path}/embedded/bin/svlogd"
-node.set['runit']['chpst_bin']    = "#{install_path}/embedded/bin/chpst"
-node.set['runit']['service_dir']  = "#{install_path}/service"
-node.set['runit']['sv_dir']       = "#{install_path}/sv"
-node.set['runit']['lsb_init_dir'] = "#{install_path}/init"
+node.override['runit']['sv_bin']       = "#{install_path}/embedded/bin/sv"
+node.override['runit']['svlogd_bin']   = "#{install_path}/embedded/bin/svlogd"
+node.override['runit']['chpst_bin']    = "#{install_path}/embedded/bin/chpst"
+node.override['runit']['service_dir']  = "#{install_path}/service"
+node.override['runit']['sv_dir']       = "#{install_path}/sv"
+node.override['runit']['lsb_init_dir'] = "#{install_path}/init"
 
 component_runit_supervisor node['enterprise']['name'] do
   ctl_name node[node['enterprise']['name']]['ctl_name'] ||


### PR DESCRIPTION
### Description

This cleans up a handful of deprecation warnings that show up
when running Chef 12 or later.

### Issues Resolved

None
### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] ~New functionality includes testing.~ No new functionality
- [x] ~New functionality has been documented in the README if applicable~
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>



Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>