### PR TITLE
[systemd] reload systemd after adding/removing unit files

### DIFF
--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -16,13 +16,12 @@ RSpec.shared_examples 'systemd create' do
     )
   end
 
-  # TODO:  Get this working with the guard.
   it 'removes unit files previously created in /usr/lib/systemd/system' do
     allow(::File).to receive(:exist?).and_call_original
-    allow(::File).to receive(:exist?).with("/usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service").and_return true
-    expect(chef_run).to run_execute('cleanup_old_unit_files').with(
-      command: "              rm /usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service\n              systemctl daemon-reload\n"
-    )
+    old_file = "/usr/lib/systemd/system/#{enterprise_name}-runsvdir-start.service"
+    allow(::File).to receive(:exist?).with(old_file).and_return true
+    expect(chef_run).to delete_file(old_file)
+    expect(chef_run.file(old_file)).to notify('execute[systemctl daemon-reload]').to(:run).immediately
   end
 
   it 'enables the service' do


### PR DESCRIPTION
### Description
You must reload systemd after adding/removing unit files

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved
Fixes new servers that run into:

```
---- End output of /usr/bin/systemctl --system start
private_chef-runsvdir-start.service ----
Ran /usr/bin/systemctl --system start private_chef-runsvdir-start.service
returned 5
STDERR:
---- End output of /usr/bin/chef-server-ctl reconfigure ----
Ran /usr/bin/chef-server-ctl reconfigure returned 1
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
