### PR TITLE
Set systemd TasksMax to infinity

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,9 @@ platforms:
   - name: ubuntu-16.04
     run_list:
       - recipe[apt::default]
+  - name: ubuntu-18.04
+    run_list:
+      - recipe[apt::default]
 
 suites:
   - name: component_runit_supervisor_create

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs common libraries and resources for Chef server and add-ons'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.13.0'
+version '0.14.0'
 
 depends 'runit', '> 1.6.0'
 

--- a/spec/recipes/runit_spec.rb
+++ b/spec/recipes/runit_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'enterprise::runit' do
   subject(:chef_run) do
     ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-      node.set['enterprise']['name'] = 'testproject'
-      node.set['testproject']['install_path'] = '/opt/testproject'
-      node.set['testproject']['sysvinit_id'] = 'TP'
+      node.normal['enterprise']['name'] = 'testproject'
+      node.normal['testproject']['install_path'] = '/opt/testproject'
+      node.normal['testproject']['sysvinit_id'] = 'TP'
     end.converge(described_recipe)
   end
 

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -223,7 +223,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
   before :each do
     # Set the node project_name
-    runner.node.set['enterprise']['name'] = enterprise_name
+    runner.node.normal['enterprise']['name'] = enterprise_name
   end
 
   describe 'component_runit_supervisor resource' do
@@ -324,7 +324,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
   before :each do
     # Set the node project_name
-    runner.node.set['enterprise']['name'] = enterprise_name
+    runner.node.normal['enterprise']['name'] = enterprise_name
   end
 
   describe 'component_runit_supervisor resource' do

--- a/templates/runsvdir-start.service.erb
+++ b/templates/runsvdir-start.service.erb
@@ -5,6 +5,10 @@ After=network.target auditd.service
 [Service]
 ExecStart=<%= @install_path %>/embedded/bin/runsvdir-start
 Restart=always
+<% if node['packages']['systemd'] && node['packages']['systemd']['version'].to_i >= 228 %>
+# only valid for systemd >= 228
+TasksMax=infinity
+<% end %>
 
 [Install]
 WantedBy=multi-user.target

--- a/test/integration/component_runit_supervisor_create/inspec/default_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/default_spec.rb
@@ -1,3 +1,5 @@
+s = service('sshd')
+
 # Child processes of runsvdir
 ['runsv a', 'runsv b', 'yes', 'yes n'].each do |p|
   describe processes(p) do

--- a/test/integration/component_runit_supervisor_create/inspec/default_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/default_spec.rb
@@ -1,5 +1,3 @@
-s = service('sshd')
-
 # Child processes of runsvdir
 ['runsv a', 'runsv b', 'yes', 'yes n'].each do |p|
   describe processes(p) do

--- a/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
@@ -6,7 +6,7 @@ if service('sshd').type == 'systemd'
   end
 
   describe file('/etc/systemd/system/testproject-runsvdir-start.service') do
-    if (package('systemd').version.to_i >= 228)
+    if package('systemd').version.to_i >= 228
       its(:content) { is_expected.to match(/TasksMax/) }
     else
       its(:content) { is_expected.not_to match(/TasksMax/) }

--- a/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
@@ -1,8 +1,15 @@
-if (os[:family] == 'redhat' && os[:release].to_i == 7) ||
-   (os[:family] == 'ubuntu' && os[:release] == '16.04')
+if service('sshd').type == 'systemd'
   describe systemd_service('testproject-runsvdir-start.service') do
     it { should be_installed }
     it { should be_enabled }
     it { should be_running }
+  end
+
+  describe file('/etc/systemd/system/testproject-runsvdir-start.service') do
+    if (package('systemd').version.to_i >= 228)
+      its(:content) { is_expected.to match(/TasksMax/) }
+    else
+      its(:content) { is_expected.not_to match(/TasksMax/) }
+    end
   end
 end

--- a/test/integration/component_runit_supervisor_create/inspec/sysvinit_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/sysvinit_spec.rb
@@ -1,5 +1,6 @@
-if (os[:family] == 'redhat' && os[:release].to_i == 5) ||
-   os[:family] == 'debian'
+if service('sshd').type == 'sysv' &&
+   # service identifies redhat 6 as sysv, but we install under upstart
+   !(os['family'] == 'redhat' && os['release'].to_i == 6)
   describe command("pgrep -f 'runsvdir.*\/opt\/tp'") do
     its(:exit_status) { should eq(0) }
   end

--- a/test/integration/component_runit_supervisor_create/inspec/upstart_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/upstart_spec.rb
@@ -1,5 +1,6 @@
-if (os[:family] == 'redhat' && os[:release].to_i == 6) ||
-   (os[:family] == 'ubuntu' && os[:release] != '16.04')
+if service('sshd').type == 'upstart' ||
+   # service identifies redhat 6 as sysv, but we install as upstart
+   (os['family'] == 'redhat' && os['release'].to_i == 6)
   describe command('initctl status testproject-runsvdir') do
     its(:stdout) { should match(/start\/running/) }
   end

--- a/test/integration/component_runit_supervisor_delete/inspec/systemd_spec.rb
+++ b/test/integration/component_runit_supervisor_delete/inspec/systemd_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'redhat' && os[:release].to_i == 7
+if service('sshd').type == 'systemd'
   describe systemd_service('testproject-runsvdir-start.service') do
     it { should_not be_installed }
     it { should_not be_enabled }

--- a/test/integration/component_runit_supervisor_delete/inspec/sysvinit_spec.rb
+++ b/test/integration/component_runit_supervisor_delete/inspec/sysvinit_spec.rb
@@ -1,5 +1,6 @@
-if (os[:family] == 'redhat' && os[:release].to_i == 5) ||
-   os[:family] == 'debian'
+if service('sshd').type == 'sysv' &&
+  # service identifies redhat 6 as sysv, but we install under upstart
+  !(os['family'] == 'redhat' && os['release'].to_i == 6)
   describe command("ps x | grep 'runsvdir.*\/opt\/tp' | grep -v grep") do
     its(:exit_status) { should eq(1) }
   end

--- a/test/integration/component_runit_supervisor_delete/inspec/sysvinit_spec.rb
+++ b/test/integration/component_runit_supervisor_delete/inspec/sysvinit_spec.rb
@@ -1,6 +1,5 @@
-if service('sshd').type == 'sysv' &&
-  # service identifies redhat 6 as sysv, but we install under upstart
-  !(os['family'] == 'redhat' && os['release'].to_i == 6)
+# service identifies redhat 6 as sysv, but we install under upstart
+if service('sshd').type == 'sysv' && !(os['family'] == 'redhat' && os['release'].to_i == 6)
   describe command("ps x | grep 'runsvdir.*\/opt\/tp' | grep -v grep") do
     its(:exit_status) { should eq(1) }
   end

--- a/test/integration/component_runit_supervisor_delete/inspec/upstart_spec.rb
+++ b/test/integration/component_runit_supervisor_delete/inspec/upstart_spec.rb
@@ -1,5 +1,6 @@
-if (os[:family] == 'redhat' && os[:release].to_i == 6) ||
-   os[:family] == 'ubuntu'
+if service('sshd').type == 'upstart' ||
+   # service identifies redhat 6 as sysv, but we install as upstart
+   (os['family'] == 'redhat' && os['release'].to_i == 6)
   describe service('testproject-runsvdir') do
     it { should_not be_running }
   end


### PR DESCRIPTION
### Description

Systemd 228 reduced the max number of tasks allowed to 512, which when
exceeded causes solr to fail with the somewhat opaque message
'java.lang.OutOfMemoryError: unable to create new native
thread'. Since the runit process group encompasses all of the chef
services, that isn't too hard to hit.

SLES-12 and Ubuntu 16.04 appear to include this version of Systemd. In
particular, our SLES-12 tester was hitting this during pedant runs,
and all the search tests were imploding in our face.

Thanks to @nsdavidson for the detective work that got to the root cause.

References:
The helpful post that got us on the right track:
https://www.elastic.co/blog/we-are-out-of-memory-systemd-process-limits

The systemd issue created:
https://github.com/systemd/systemd/issues/3211

Documentation on the TasksMax setting:
man systemd.resource-control

### Issues Resolved

No issues attached.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
