### PR TITLE
Pin runit cookbook to v4.1.1.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs common libraries and resources for Chef server and add-ons
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.14.0'
 
-depends 'runit', '> 1.6.0'
+depends 'runit', '= 4.1.1'
 
 source_url 'https://github.com/chef-cookbooks/enterprise'
 issues_url 'https://github.com/chef-cookbooks/enterprise/issues'


### PR DESCRIPTION
### Description
There was a bugfix in the runit cookbook introduced in v4.1.2 which changed the init.d from a symlink of the sv binary to a init.d script. This script correctly has a hard-coded `PATH` variable which does not
include the omnibus path, causing the rabbitmq init script to fail via chef-server-ctl/runit when it is invoked manually. Unfortunately, there seems to be some scope issues with custom resources in Chef 14 which are preventing us from overriding the template used by the runit cookbook without a significant effort in rewriting all the runit usage in this and the private-chef cookbooks.

### Issues Resolved

* Internal issue: SUSTAIN-985

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
