### PR TITLE
Modernize our usage of runit and remove keepalived suspport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 This file is used to list changes made in each version of the enterprise cookbook.
 
-## 0.15.0 WIP
+## 0.15.0 (2019-06-03)
 
-- Remove fedora from the metadata since we don't actually require it
-- Refactor component_runit_service to use the new :reload_log action in runit cookbook 5.1's runit_service resource
-- Removed the chefspec matchers that aren't needed by modern chefspec
+- Update for and require the new runit cookbook v5.0.1
+- Remove support for keepalived in Chef HA
+- Remove the ChefSpec matchers that are no longer necessary with modern ChefSpec
+- Remove fedora from the metadata since we don't actually support it
+- Refactor component_runit_service to use the new :reload_log action in runit cookbook 5.X's runit_service resource
 - Require Chef 13 or later
 - Remove support for Debian < 8 and RHEL < 6
+- Update the specs for modern platforms
 
 ## 0.14.2 (2018-11-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the enterprise cookbook.
 
+## 0.15.0 WIP
+
+- Remove fedora from the metadata since we don't actually require it
+- Refactor component_runit_service to use the new :reload_log action in runit cookbook 5.1's runit_service resource
+- Removed the chefspec matchers that aren't needed by modern chefspec
+- Require Chef 13 or later
+
 ## 0.14.2 (2018-11-28)
 
 - turn component_runit_service into a custom resource [\#67]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the enterprise cookboo
 - Refactor component_runit_service to use the new :reload_log action in runit cookbook 5.1's runit_service resource
 - Removed the chefspec matchers that aren't needed by modern chefspec
 - Require Chef 13 or later
+- Remove support for Debian < 8 and RHEL < 6
 
 ## 0.14.2 (2018-11-28)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/chef-cookbooks/enterprise-chef-common.svg?branch=master)](http://travis-ci.org/chef-cookbooks/enterprise-chef-common)
 
-This cookbook provides common functionality needed for Chef server, Push jobs, Reporting, and other enterprise-grade Omnibus projects.
+This cookbook provides common functionality needed for Chef Server, Push Jobs, Reporting, and other enterprise-grade Omnibus projects.
 
 Your omnibus project attributes should define the following attributes:
 
@@ -30,13 +30,11 @@ Optional attributes are:
 
 Sets the proper attributes to use runit and creates a runit supervisor to be used by component runit services.
 
-## Definitions
+## Resources
 
 ### component_runit_service
 
 Defines a runit service.
-
-## Resources
 
 ### component_runit_supervisor
 
@@ -62,7 +60,7 @@ Creates a runit runsvdir process to monitor component runit processes.
 
 ## Testing
 
-[ChefDK](http://downloads.chef.io/chef-dk/) must be installed
+[ChefDK](https://downloads.chef.io/chefdk) must be installed
 
 ### ChefSpec
 
@@ -70,7 +68,7 @@ Run `chef exec rspec` to run ChefSpec examples.
 
 ### Test Kitchen
 
-Integration tests can be run with [Test Kitchen](http://kitchen.ci/).
+Integration tests can be run with [Test Kitchen](https://kitchen.ci/).
 
 ## Maintainers
 
@@ -78,7 +76,7 @@ This cookbook is maintained by Chef's Community Cookbook Engineering team. Our g
 
 ## License
 
-**Copyright:** 2013-2017, Chef Software, Inc.
+**Copyright:** 2013-2019, Chef Software, Inc.
 
 ```
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Optional attributes are:
 - `node[project_name]['topology']` one of `standalone`, `tier`, or `ha`.
 - `node[project_name]['role']` either `backend` or `frontend`.
 - `node[project_name]['servers'][node_name]['bootstrap']` is used to determine if the node is installation bootstrap server. Value is treated as boolean.
-- `node[project_name]['keepalived']['dir']` directory for keepalived.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
 default['enterprise']['name'] = 'private_chef'
+
+default['runit']

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,6 +1,0 @@
-if defined?(ChefSpec)
-  def create_component_runit_supervisor(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new('component_runit_supervisor',
-                                            'create', resource_name)
-  end
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs common libraries and resources for Chef server and add-ons'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.14.2'
+version '0.15.0'
 
-depends 'runit', '= 4.1.1'
+depends 'runit', '= 5.0.1'
 
 source_url 'https://github.com/chef-cookbooks/enterprise'
 issues_url 'https://github.com/chef-cookbooks/enterprise/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,6 @@ issues_url 'https://github.com/chef-cookbooks/enterprise/issues'
 
 chef_version '>= 12.7' if respond_to?(:chef_version)
 
-%w(redhat oracle centos scientific fedora amazon debian ubuntu).each do |os|
+%w(redhat oracle centos scientific amazon debian ubuntu).each do |os|
   supports os
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs common libraries and resources for Chef server and add-ons
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.15.0'
 
-depends 'runit', '= 5.0.1'
+depends 'runit', '= 5.1.1'
 
 source_url 'https://github.com/chef-cookbooks/enterprise'
 issues_url 'https://github.com/chef-cookbooks/enterprise/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ depends 'runit', '= 5.0.1'
 source_url 'https://github.com/chef-cookbooks/enterprise'
 issues_url 'https://github.com/chef-cookbooks/enterprise/issues'
 
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 13'
 
 %w(redhat oracle centos scientific amazon debian ubuntu).each do |os|
   supports os

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -62,6 +62,7 @@ action :enable do
     action :enable
     retries 20
     control new_resource.control if new_resource.control
+    use_init_script_sv_link true
     options(
       log_directory: log_directory
     )

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -45,20 +45,13 @@ action :enable do
   svlogd_size = new_resource.svlogd_size || node[new_resource.package][new_resource.component]['log_rotation']['file_maxbytes']
   svlogd_num = new_resource.svlogd_num || node[new_resource.package][new_resource.component]['log_rotation']['num_to_keep']
 
-  # runit resources don't support reloading the log service as an action :(
-  execute "restart_#{new_resource.component}_log_service" do
-    runit_service new_resource.component do
-      action :restart
-    end
-  end
-
   template "#{log_directory}/config" do
     source 'config.svlogd'
     cookbook 'enterprise'
     mode '0644'
     owner 'root'
     group 'root'
-    notifies :run, "execute[restart_#{new_resource.component}_log_service]"
+    notifies :reload_log, "runit_service[new_resource.component]"
     variables(
       svlogd_size: svlogd_size,
       svlogd_num: svlogd_num

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -77,7 +77,7 @@ action :down do
   end
 end
 
-[:start, :restart, :stop, :reload, :disable].each do |action_name|
+[:start, :restart, :stop, :reload, :disable, :create].each do |action_name|
   action action_name do
     runit_service new_resource.component do
       action action_name

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -75,28 +75,6 @@ action :enable do
       send(attr_name.to_sym, attr_value)
     end
   end
-
-  # Keepalive management
-  #
-  # Our keepalived setup knows which services it must manage by
-  # looking for a 'keepalive_me' sentinel file in the service's
-  # directory.
-  if EnterpriseChef::Helpers.ha?(node)
-    # We need special handling for the ha param, as it's a boolean and
-    # could be false, so we explicitly check for nil?
-    is_keepalive_service = if new_resource.ha.nil?
-                             node[new_resource.package][new_resource.component]['ha']
-                           else
-                             new_resource.ha
-                           end
-    file "#{node['runit']['sv_dir']}/#{new_resource.component}/keepalive_me" do
-      action is_keepalive_service ? :create : :delete
-    end
-
-    file "#{node['runit']['sv_dir']}/#{new_resource.component}/down" do
-      action is_keepalive_service ? :create : :delete
-    end
-  end
 end
 
 action :down do

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -51,7 +51,7 @@ action :enable do
     mode '0644'
     owner 'root'
     group 'root'
-    notifies :reload_log, "runit_service[new_resource.component]"
+    notifies :reload_log, "runit_service[#{new_resource.component}]", :delayed
     variables(
       svlogd_size: svlogd_size,
       svlogd_num: svlogd_num

--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -47,8 +47,9 @@ action :enable do
 
   # runit resources don't support reloading the log service as an action :(
   execute "restart_#{new_resource.component}_log_service" do
-    command "#{node['runit']['sv_bin']} restart #{node['runit']['sv_dir']}/#{new_resource.component}/log"
-    action :nothing
+    runit_service new_resource.component do
+      action :restart
+    end
   end
 
   template "#{log_directory}/config" do

--- a/resources/component_runit_supervisor_sysvinit.rb
+++ b/resources/component_runit_supervisor_sysvinit.rb
@@ -21,10 +21,6 @@ include ComponentRunitSupervisorResourceMixin
 provides :component_runit_supervisor, platform_family: 'suse' do |node|
   node['platform_version'].to_i == 11
 end
-provides :component_runit_supervisor, platform: 'debian'
-provides :component_runit_supervisor, platform_family: 'rhel' do |node|
-  node['platform_version'].to_i == 5
-end
 
 action :create do
   execute "echo '#{svdir_line}' >> /etc/inittab" do

--- a/resources/component_runit_supervisor_upstart.rb
+++ b/resources/component_runit_supervisor_upstart.rb
@@ -21,9 +21,7 @@ include ComponentRunitSupervisorResourceMixin
 provides :component_runit_supervisor, platform_family: 'rhel' do |node|
   node['platform_version'].to_i == 6
 end
-provides :component_runit_supervisor, platform: 'fedora' do |node|
-  node['platform_version'].to_i <= 14
-end
+
 provides :component_runit_supervisor,
          platform: %w(amazon ubuntu)
 

--- a/spec/resources/component_runit_service_spec.rb
+++ b/spec/resources/component_runit_service_spec.rb
@@ -140,66 +140,6 @@ describe 'component_runit_service' do
         )
       end
     end
-
-    context 'keepalive management in an HA topology' do
-      default_attributes['awesomeproduct']['topology'] = 'ha'
-      default_attributes['awesomeproduct']['haservice']['log_directory'] = '/var/log/awesomeproduct/haservice'
-      default_attributes['awesomeproduct']['haservice']['log_rotation']['num_to_keep'] = 42
-      default_attributes['awesomeproduct']['haservice']['log_rotation']['file_maxbytes'] = 8675309
-
-      recipe do
-        component_runit_service 'haservice' do
-          package 'awesomeproduct'
-        end
-      end
-
-      context 'by default' do
-        it { is_expected.to delete_file('/var/opt/runit/haservice/keepalive_me') }
-        it { is_expected.to delete_file('/var/opt/runit/haservice/down') }
-      end
-
-      context 'when HA is disabled for the component' do
-        context 'via node attributes' do
-          default_attributes['awesomeproduct']['haservice']['ha'] = false
-
-          it { is_expected.to delete_file('/var/opt/runit/haservice/keepalive_me') }
-          it { is_expected.to delete_file('/var/opt/runit/haservice/down') }
-        end
-
-        context 'via resource parameters' do
-          recipe do
-            component_runit_service 'haservice' do
-              package 'awesomeproduct'
-              ha false
-            end
-          end
-
-          it { is_expected.to delete_file('/var/opt/runit/haservice/keepalive_me') }
-          it { is_expected.to delete_file('/var/opt/runit/haservice/down') }
-        end
-      end
-
-      context 'when HA is enabled for the component' do
-        context 'via node attributes' do
-          default_attributes['awesomeproduct']['haservice']['ha'] = true
-
-          it { is_expected.to create_file('/var/opt/runit/haservice/keepalive_me') }
-          it { is_expected.to create_file('/var/opt/runit/haservice/down') }
-        end
-
-        context 'via resource parameters' do
-          recipe do
-            component_runit_service 'haservice' do
-              package 'awesomeproduct'
-              ha true
-            end
-          end
-
-          it { is_expected.to create_file('/var/opt/runit/haservice/keepalive_me') }
-          it { is_expected.to create_file('/var/opt/runit/haservice/down') }
-        end
-      end
-    end
   end
 
   context 'action :down' do

--- a/spec/resources/component_runit_service_spec.rb
+++ b/spec/resources/component_runit_service_spec.rb
@@ -23,11 +23,6 @@ describe 'component_runit_service' do
         expect(chef_run).to enable_component_runit_service('sweetservice')
       end
 
-      it 'creates a resource to restart the component\'s svlog service, but does not run it yet' do
-        expect(chef_run).to nothing_execute('restart_sweetservice_log_service')
-          .with(command: '/opt/runit restart /var/opt/runit/sweetservice/log')
-      end
-
       it 'renders the svlogd template' do
         expect(chef_run).to create_template('/var/log/awesomeproduct/sweetservice/config').with(
           owner: 'root',

--- a/spec/resources/component_runit_service_spec.rb
+++ b/spec/resources/component_runit_service_spec.rb
@@ -42,7 +42,7 @@ describe 'component_runit_service' do
       end
 
       it 'notifies the svlog service restarter to run if the svlog template renders with changes' do
-        expect(chef_run.template('/var/log/awesomeproduct/sweetservice/config')).to notify('execute[restart_sweetservice_log_service]')
+        expect(chef_run.template('/var/log/awesomeproduct/sweetservice/config')).to notify('runit_service[sweetservice]')
       end
 
       it 'enables a runit service' do

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -345,7 +345,6 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'systemd delete'
       end
 
-
       context 'when on RHEL 6 with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'centos', version: '6',

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -246,16 +246,6 @@ describe 'enterprise_test::component_runit_supervisor_create' do
         it_behaves_like 'sysvinit create'
       end
 
-      context 'when on Fedora' do
-        let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'fedora', version: '25', step_into: ['component_runit_supervisor'] do |node|
-            node.default['init_package'] = 'systemd'
-          end
-        end
-
-        it_behaves_like 'systemd create'
-      end
-
       context 'when on RHEL 5' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'centos', version: '5.11',
@@ -345,16 +335,6 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         end
 
         it_behaves_like 'sysvinit delete'
-      end
-
-      context 'when on Fedora' do
-        let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'fedora', version: '25', step_into: ['component_runit_supervisor'] do |node|
-            node.default['init_package'] = 'systemd'
-          end
-        end
-
-        it_behaves_like 'systemd delete'
       end
 
       context 'when on RHEL 5' do

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -228,7 +228,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
   describe 'component_runit_supervisor resource' do
     describe 'action :create' do
-      context 'when on Amazon Linux' do
+      context 'when on Amazon Linux 201X with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'amazon', version: '2018.03',
                                    step_into: ['component_runit_supervisor']
@@ -237,25 +237,16 @@ describe 'enterprise_test::component_runit_supervisor_create' do
         it_behaves_like 'upstart create'
       end
 
-      context 'when on Debian' do
+      context 'when on Amazon Linux 2 with systemd' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'debian', version: '7.11',
+          ChefSpec::SoloRunner.new platform: 'amazon', version: '2',
                                    step_into: ['component_runit_supervisor']
         end
 
-        it_behaves_like 'sysvinit create'
+        it_behaves_like 'systemd create'
       end
 
-      context 'when on RHEL 5' do
-        let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '5.11',
-                                   step_into: ['component_runit_supervisor']
-        end
-
-        it_behaves_like 'sysvinit create'
-      end
-
-      context 'when on RHEL 6' do
+      context 'when on RHEL 6 with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'centos', version: '6',
                                    step_into: ['component_runit_supervisor']
@@ -267,16 +258,15 @@ describe 'enterprise_test::component_runit_supervisor_create' do
       context 'when on RHEL 7 with systemd' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'centos', version: '7', step_into: ['component_runit_supervisor'] do |node|
-            node.default['init_package'] = 'systemd'
           end
         end
 
         it_behaves_like 'systemd create'
       end
 
-      context 'when on SuSE 11' do
+      context 'when on SuSE 11 with sysv' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'suse', version: '11.4',
+          ChefSpec::SoloRunner.new platform: 'suse', version: '11',
                                    step_into: ['component_runit_supervisor']
         end
 
@@ -285,7 +275,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
       context 'when on SuSE 12 with systemd' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'suse', version: '12.1', step_into: ['component_runit_supervisor'] do |node|
+          ChefSpec::SoloRunner.new platform: 'suse', version: '12', step_into: ['component_runit_supervisor'] do |node|
             node.default['init_package'] = 'systemd'
           end
         end
@@ -293,13 +283,22 @@ describe 'enterprise_test::component_runit_supervisor_create' do
         it_behaves_like 'systemd create'
       end
 
-      context 'when on Ubuntu' do
+      context 'when on Ubuntu 14 with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'ubuntu', version: '14.04',
                                    step_into: ['component_runit_supervisor']
         end
 
         it_behaves_like 'upstart create'
+      end
+
+      context 'when on Ubuntu 16 with systemd' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'ubuntu', version: '16.04',
+                                   step_into: ['component_runit_supervisor']
+        end
+
+        it_behaves_like 'systemd create'
       end
     end
   end
@@ -328,25 +327,26 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'upstart delete'
       end
 
-      context 'when on Debian' do
+      context 'when on Amazon 201X' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'debian', version: '7.11',
+          ChefSpec::SoloRunner.new platform: 'amazon', version: '2018.03',
                                    step_into: ['component_runit_supervisor']
         end
 
-        it_behaves_like 'sysvinit delete'
+        it_behaves_like 'upstart delete'
       end
 
-      context 'when on RHEL 5' do
+      context 'when on Amazon 2' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '5.11',
+          ChefSpec::SoloRunner.new platform: 'amazon', version: '2',
                                    step_into: ['component_runit_supervisor']
         end
 
-        it_behaves_like 'sysvinit delete'
+        it_behaves_like 'systemd delete'
       end
 
-      context 'when on RHEL 6' do
+
+      context 'when on RHEL 6 with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'centos', version: '6',
                                    step_into: ['component_runit_supervisor']
@@ -365,7 +365,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'systemd delete'
       end
 
-      context 'when on SuSE 11' do
+      context 'when on SuSE 11 with sysv' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'suse', version: '11',
                                    step_into: ['component_runit_supervisor']
@@ -374,23 +374,29 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
         it_behaves_like 'sysvinit delete'
       end
 
-      context 'when on SuSE 12' do
+      context 'when on SuSE 12 with systemd' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'suse', version: '12', step_into: ['component_runit_supervisor'] do |node|
-            node.default['init_package'] = 'systemd'
-          end
+          ChefSpec::SoloRunner.new platform: 'suse', version: '12', step_into: ['component_runit_supervisor']
         end
 
         it_behaves_like 'systemd delete'
       end
 
-      context 'when on Ubuntu' do
+      context 'when on Ubuntu with upstart' do
         let(:runner) do
           ChefSpec::SoloRunner.new platform: 'ubuntu', version: '14.04',
                                    step_into: ['component_runit_supervisor']
         end
 
         it_behaves_like 'upstart delete'
+      end
+
+      context 'when on Ubuntu with systemd' do
+        let(:runner) do
+          ChefSpec::SoloRunner.new platform: 'ubuntu', version: '16.04', step_into: ['component_runit_supervisor']
+        end
+
+        it_behaves_like 'systemd delete'
       end
     end
   end

--- a/spec/resources/component_runit_supervisor_spec.rb
+++ b/spec/resources/component_runit_supervisor_spec.rb
@@ -230,7 +230,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
     describe 'action :create' do
       context 'when on Amazon Linux' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'amazon', version: '2017.03',
+          ChefSpec::SoloRunner.new platform: 'amazon', version: '2018.03',
                                    step_into: ['component_runit_supervisor']
         end
 
@@ -257,7 +257,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
       context 'when on RHEL 6' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '6.9',
+          ChefSpec::SoloRunner.new platform: 'centos', version: '6',
                                    step_into: ['component_runit_supervisor']
         end
 
@@ -266,7 +266,7 @@ describe 'enterprise_test::component_runit_supervisor_create' do
 
       context 'when on RHEL 7 with systemd' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '7.3.1611', step_into: ['component_runit_supervisor'] do |node|
+          ChefSpec::SoloRunner.new platform: 'centos', version: '7', step_into: ['component_runit_supervisor'] do |node|
             node.default['init_package'] = 'systemd'
           end
         end
@@ -348,7 +348,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
       context 'when on RHEL 6' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '6.9',
+          ChefSpec::SoloRunner.new platform: 'centos', version: '6',
                                    step_into: ['component_runit_supervisor']
         end
 
@@ -357,7 +357,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
       context 'when on RHEL 7 with systemd' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'centos', version: '7.3.1611', step_into: ['component_runit_supervisor'] do |node|
+          ChefSpec::SoloRunner.new platform: 'centos', version: '7', step_into: ['component_runit_supervisor'] do |node|
             node.default['init_package'] = 'systemd'
           end
         end
@@ -367,7 +367,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
       context 'when on SuSE 11' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'suse', version: '11.4',
+          ChefSpec::SoloRunner.new platform: 'suse', version: '11',
                                    step_into: ['component_runit_supervisor']
         end
 
@@ -376,7 +376,7 @@ describe 'enterprise_test::component_runit_supervisor_delete' do
 
       context 'when on SuSE 12' do
         let(:runner) do
-          ChefSpec::SoloRunner.new platform: 'suse', version: '12.2', step_into: ['component_runit_supervisor'] do |node|
+          ChefSpec::SoloRunner.new platform: 'suse', version: '12', step_into: ['component_runit_supervisor'] do |node|
             node.default['init_package'] = 'systemd'
           end
         end

--- a/test/fixtures/cookbooks/enterprise_test/recipes/setup.rb
+++ b/test/fixtures/cookbooks/enterprise_test/recipes/setup.rb
@@ -31,11 +31,20 @@ file '/opt/tp/service/b/run' do
   content "#!/bin/sh\nexec yes n"
 end
 
+# Short term hack until figure out stragegy with new runit
+# Need to figure out how to extract properties from the runit
+runit_bin = case node['platform_family']
+            when 'debian'
+              '/usr/bin/sv'
+            when 'rhel', 'amazon'
+              '/sbin/sv'
+            end
+
 # Symlink the runit binaries we need into our directory. In real life these
 # would have been installed in the directory above
 %w(runsv runsvdir sv).each do |bin|
   link "/opt/tp/embedded/bin/#{bin}" do
-    to "#{File.dirname(node['runit']['sv_bin'])}/#{bin}"
+    to "#{File.dirname(runit_bin)}/#{bin}"
   end
 end
 

--- a/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
+++ b/test/integration/component_runit_supervisor_create/inspec/systemd_spec.rb
@@ -6,10 +6,12 @@ if service('sshd').type == 'systemd'
   end
 
   describe file('/etc/systemd/system/testproject-runsvdir-start.service') do
-    if package('systemd').version.to_i >= 228
-      its(:content) { is_expected.to match(/TasksMax/) }
-    else
-      its(:content) { is_expected.not_to match(/TasksMax/) }
+    its(:content) do
+      if package('systemd').version.to_i >= 228
+        is_expected.to match(/TasksMax/)
+      else
+        is_expected.not_to match(/TasksMax/)
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

Update to runit 5.x cookbook, which had to be updated to continue to work with this workflow.

This also drops support for long EOL linux distros and requires Chef 13+