### PR TITLE
Create the service but do not start it

### DIFF
--- a/resources/component_runit_service.rb
+++ b/resources/component_runit_service.rb
@@ -40,34 +40,36 @@ property :control, Array # control signal overrides for runit and runsv
 # resource that are not explicitly supported by this resource
 property :runit_attributes, Hash, default: {}
 
-action :enable do
-  log_directory = new_resource.log_directory || node[new_resource.package][new_resource.component]['log_directory']
-  svlogd_size = new_resource.svlogd_size || node[new_resource.package][new_resource.component]['log_rotation']['file_maxbytes']
-  svlogd_num = new_resource.svlogd_num || node[new_resource.package][new_resource.component]['log_rotation']['num_to_keep']
+[:create, :enable].each do |action_name|
+  action action_name do
+    log_directory = new_resource.log_directory || node[new_resource.package][new_resource.component]['log_directory']
+    svlogd_size = new_resource.svlogd_size || node[new_resource.package][new_resource.component]['log_rotation']['file_maxbytes']
+    svlogd_num = new_resource.svlogd_num || node[new_resource.package][new_resource.component]['log_rotation']['num_to_keep']
 
-  template "#{log_directory}/config" do
-    source 'config.svlogd'
-    cookbook 'enterprise'
-    mode '0644'
-    owner 'root'
-    group 'root'
-    notifies :reload_log, "runit_service[#{new_resource.component}]", :delayed
-    variables(
-      svlogd_size: svlogd_size,
-      svlogd_num: svlogd_num
-    )
-  end
+    template "#{log_directory}/config" do
+      source 'config.svlogd'
+      cookbook 'enterprise'
+      mode '0644'
+      owner 'root'
+      group 'root'
+      notifies :reload_log, "runit_service[#{new_resource.component}]", :delayed
+      variables(
+        svlogd_size: svlogd_size,
+        svlogd_num: svlogd_num
+      )
+    end
 
-  runit_service new_resource.component do
-    action :enable
-    retries 20
-    control new_resource.control if new_resource.control
-    use_init_script_sv_link true
-    options(
-      log_directory: log_directory
-    )
-    new_resource.runit_attributes.each do |attr_name, attr_value|
-      send(attr_name.to_sym, attr_value)
+    runit_service new_resource.component do
+      action action_name
+      retries 20
+      control new_resource.control if new_resource.control
+      use_init_script_sv_link true
+      options(
+        log_directory: log_directory
+      )
+      new_resource.runit_attributes.each do |attr_name, attr_value|
+        send(attr_name.to_sym, attr_value)
+      end
     end
   end
 end
@@ -78,7 +80,7 @@ action :down do
   end
 end
 
-[:start, :restart, :stop, :reload, :disable, :create].each do |action_name|
+[:start, :restart, :stop, :reload, :disable].each do |action_name|
   action action_name do
     runit_service new_resource.component do
       action action_name


### PR DESCRIPTION
Some of the services (e.g: opscode-chef-mover in chef-server) using the wrapper
need the service to be created but not started.
The options for log_directory need to be set on a create so that
starting the service for install-upgrade works.

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
