### PR TITLE
Work with Chef Infra Client 16

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache-2.0'
 description 'Installs common libraries and resources for Chef server and add-ons'
 version '1.0.0'
 
-depends 'runit', '= 5.1.1'
+depends 'runit', '>= 5.1.1'
 
 source_url 'https://github.com/chef-cookbooks/enterprise-chef-common'
 issues_url 'https://github.com/chef-cookbooks/enterprise-chef-common/issues'

--- a/resources/component_runit_supervisor.rb
+++ b/resources/component_runit_supervisor.rb
@@ -16,11 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 include ComponentRunitSupervisorResourceMixin
 
-provides :component_runit_supervisor do |node|
-  node['init_package'] == 'systemd'
-end
+provides :component_runit_supervisor
 
 action :create do
   template "/etc/systemd/system/#{unit_name}" do


### PR DESCRIPTION
Nuke a complex provides line that wasn't getting us anything since
there's only one resource now

Require a modern runit release that works on Chef 16+

Signed-off-by: Tim Smith <tsmith@chef.io>